### PR TITLE
Add Java binding for `getSentenceVector`

### DIFF
--- a/src/main/cpp/fasttext_wrapper.cc
+++ b/src/main/cpp/fasttext_wrapper.cc
@@ -80,7 +80,14 @@ namespace FastTextWrapper {
 
     std::vector<real> FastTextApi::getVector(const std::string& word) {
         Vector vec(privateMembers->args_->dim);
-        fastText.getVector(vec, word);
+        fastText.getWordVector(vec, word);
+        return std::vector<real>(vec.data(), vec.data() + vec.size());
+    }
+
+    std::vector<real> FastTextApi::getSentenceVector(const std::string& sentence) {
+        Vector vec(privateMembers->args_->dim);
+        std::istringstream in(sentence);
+        fastText.getSentenceVector(in, vec);
         return std::vector<real>(vec.data(), vec.data() + vec.size());
     }
 

--- a/src/main/cpp/fasttext_wrapper.h
+++ b/src/main/cpp/fasttext_wrapper.h
@@ -29,6 +29,7 @@ namespace FastTextWrapper {
         std::vector<std::string> predict(const std::string&, int32_t);
         std::vector<std::pair<real,std::string>> predictProba(const std::string&, int32_t);
         std::vector<real> getVector(const std::string&);
+        std::vector<real> getSentenceVector(const std::string&);
         std::vector<std::string> getWords();
         std::vector<std::string> getLabels();
         std::string getWord(int32_t);

--- a/src/main/java/com/github/jfasttext/FastTextWrapper.java
+++ b/src/main/java/com/github/jfasttext/FastTextWrapper.java
@@ -201,6 +201,8 @@ public class FastTextWrapper extends com.github.jfasttext.config.FastTextWrapper
         public native @ByVal FloatStringPairVector predictProba(@StdString String arg0, int arg1);
         public native @ByVal RealVector getVector(@StdString BytePointer arg0);
         public native @ByVal RealVector getVector(@StdString String arg0);
+        public native @ByVal RealVector getSentenceVector(@StdString BytePointer arg0);
+        public native @ByVal RealVector getSentenceVector(@StdString String arg0);
         public native @ByVal StringVector getWords();
         public native @ByVal StringVector getLabels();
         public native @StdString BytePointer getWord(int arg0);

--- a/src/main/java/com/github/jfasttext/JFastText.java
+++ b/src/main/java/com/github/jfasttext/JFastText.java
@@ -93,6 +93,18 @@ public class JFastText {
         return wordVec;
     }
 
+    public List<Float> getSentenceVector(String sentence) {
+        if (!sentence.endsWith("\n")) {
+          sentence += "\n";
+        }
+        FastTextWrapper.RealVector rv = fta.getSentenceVector(sentence);
+        List<Float> wordVec = new ArrayList<>();
+        for (int i = 0; i < rv.size(); i++) {
+          wordVec.add(rv.get(i));
+        }
+        return wordVec;
+    }
+
     public int getNWords() {
         return fta.getNWords();
     }

--- a/src/test/java/com/github/jfasttext/JFastTextTest.java
+++ b/src/test/java/com/github/jfasttext/JFastTextTest.java
@@ -16,7 +16,9 @@ public class JFastTextTest {
         jft.runCmd(new String[] {
                 "supervised",
                 "-input", "src/test/resources/data/labeled_data.txt",
-                "-output", "src/test/resources/models/supervised.model"
+                "-output", "src/test/resources/models/supervised.model",
+                "-wordNgrams", "3",
+                "-bucket", "100"
         });
     }
 
@@ -86,11 +88,20 @@ public class JFastTextTest {
         System.out.printf("\nWord embedding vector of '%s': %s\n", word, vec);
     }
 
+    @Test
+    public void test08GetSentenceVector() throws Exception {
+        JFastText jft = new JFastText();
+        jft.loadModel("src/test/resources/models/supervised.model.bin");
+        String word = "soccers";
+        List<Float> vec = jft.getSentenceVector(word);
+        System.out.printf("\nSentence embedding vector of '%s': %s\n", word, vec);
+    }
+
     /**
      * Test retrieving model's information: words, labels, learning rate, etc.
      */
     @Test
-    public void test08ModelInfo() throws Exception {
+    public void test09ModelInfo() throws Exception {
         System.out.printf("\nSupervised model information:\n");
         JFastText jft = new JFastText();
         jft.loadModel("src/test/resources/models/supervised.model.bin");
@@ -113,7 +124,7 @@ public class JFastTextTest {
      * allocated by native function calls).
      */
     @Test
-    public void test09ModelUnloading() throws Exception {
+    public void test10ModelUnloading() throws Exception {
         JFastText jft = new JFastText();
         System.out.println("\nLoading model ...");
         jft.loadModel("src/test/resources/models/supervised.model.bin");


### PR DESCRIPTION
This PR adds Java binding for the `getSentenceVector`. This method can return subword-based embeddings for OOV words. Comparing to `getWordVector`, even if the input for `getSentenceVector` is OOV, it still can compute the embeddings based on in-vocab subwords.

I also modified the test cases slightly to test output embeddings for OOV words.

This is a useful method in my use case, so I'm submitting a PR in case others also want this. Feel free to comment. Thanks!