### PR TITLE
Fix issue #19 - allow to load models from InputStream/URL/URI

### DIFF
--- a/src/test/java/com/github/jfasttext/JFastTextTest.java
+++ b/src/test/java/com/github/jfasttext/JFastTextTest.java
@@ -4,6 +4,9 @@ import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.URL;
 import java.util.List;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -57,8 +60,7 @@ public class JFastTextTest {
 
     @Test
     public void test05PredictProba() throws Exception {
-        JFastText jft = new JFastText();
-        jft.loadModel("src/test/resources/models/supervised.model.bin");
+        JFastText jft = new JFastText("src/test/resources/models/supervised.model.bin");
         String text = "What is the most popular sport in the US ?";
         JFastText.ProbLabel predictedProbLabel = jft.predictProba(text);
         System.out.printf("\nText: '%s', label: '%s', probability: %f\n",
@@ -67,8 +69,7 @@ public class JFastTextTest {
 
     @Test
     public void test06MultiPredictProba() throws Exception {
-        JFastText jft = new JFastText();
-        jft.loadModel("src/test/resources/models/supervised.model.bin");
+        JFastText jft = new JFastText("src/test/resources/models/supervised.model.bin");
         String text = "Do you like soccer ?";
         System.out.printf("Text: '%s'\n", text);
         for (JFastText.ProbLabel predictedProbLabel: jft.predictProba(text, 2)) {
@@ -79,11 +80,12 @@ public class JFastTextTest {
 
     @Test
     public void test07GetVector() throws Exception {
-        JFastText jft = new JFastText();
-        jft.loadModel("src/test/resources/models/supervised.model.bin");
-        String word = "soccer";
-        List<Float> vec = jft.getVector(word);
-        System.out.printf("\nWord embedding vector of '%s': %s\n", word, vec);
+        try (InputStream is = new FileInputStream("src/test/resources/models/supervised.model.bin")) {
+            JFastText jft = new JFastText(is);
+            String word = "soccer";
+            List<Float> vec = jft.getVector(word);
+            System.out.printf("\nWord embedding vector of '%s': %s\n", word, vec);
+        }
     }
 
     /**
@@ -92,8 +94,7 @@ public class JFastTextTest {
     @Test
     public void test08ModelInfo() throws Exception {
         System.out.printf("\nSupervised model information:\n");
-        JFastText jft = new JFastText();
-        jft.loadModel("src/test/resources/models/supervised.model.bin");
+        JFastText jft = new JFastText("src/test/resources/models/supervised.model.bin");
         System.out.printf("\tnumber of words = %d\n", jft.getNWords());
         System.out.printf("\twords = %s\n", jft.getWords());
         System.out.printf("\tlearning rate = %g\n", jft.getLr());
@@ -119,5 +120,16 @@ public class JFastTextTest {
         jft.loadModel("src/test/resources/models/supervised.model.bin");
         System.out.println("Unloading model ...");
         jft.unloadModel();
+    }
+
+    /**
+     * Loads model from specified URL (resource, web, etc.)
+     *
+     */
+    @Test
+    public void test10ModelFromURL() throws Exception {
+        URL modelUrl = this.getClass().getClassLoader().getResource("models/supervised.model.bin");
+        JFastText jft = new JFastText(modelUrl);
+        System.out.printf("\tnumber of words = %d\n", jft.getNWords());
     }
 }


### PR DESCRIPTION
* Added corresponding implementations of the `loadModel` that copy data from
  `InputStream`/`URL`/`URI` into temporary file, and load it into fastText;
* Added corresponding constructors to simplify code