### PR TITLE
Fix issue #19 - allow to load models from InputStream/URL/URI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk11
 os:
   - linux
-  - osx
 cache: bundler
 # Setting install to 'true' to prevent Travis CI from installing depedencies via:
 # "mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V" which fails due to missing the GPG secret key.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/vinhkhuc/JFastText.svg?branch=master)](https://travis-ci.org/vinhkhuc/JFastText)
+[![Build Status](https://travis-ci.org/carschno/JFastText.svg?branch=master)](https://travis-ci.org/carschno/JFastText)
 
 Table of Contents
 =================
@@ -30,7 +30,7 @@ JFastText is ideal for building fast text classifiers in Java.
 <dependency>
   <groupId>com.github.vinhkhuc</groupId>
   <artifactId>jfasttext</artifactId>
-  <version>0.4</version>
+  <version>0.5</version>
 </dependency>
 ```
 The Jar package on Maven Central is bundled with precompiled fastText library for Windows, Linux and

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.vinhkhuc</groupId>
     <artifactId>jfasttext</artifactId>
-    <version>0.4</version>
+    <version>0.5</version>
     <name>Java interface for fastText</name>
     <description>
         JFastText is a Java interface for fastText, a library for efficient learning of
@@ -110,6 +110,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9.1</version>
+                <configuration>
+                    <source>8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/src/main/cpp/fasttext_wrapper.cc
+++ b/src/main/cpp/fasttext_wrapper.cc
@@ -74,13 +74,20 @@ namespace FastTextWrapper {
             const std::string& text, int32_t k) {
         std::vector<std::pair<real,std::string>> predictions;
         std::istringstream in(text);
-        fastText.predict(in, k, predictions);
+        fastText.predictLine(in, predictions, k, 0.0);
         return predictions;
     }
 
     std::vector<real> FastTextApi::getVector(const std::string& word) {
         Vector vec(privateMembers->args_->dim);
-        fastText.getVector(vec, word);
+        fastText.getWordVector(vec, word);
+        return std::vector<real>(vec.data(), vec.data() + vec.size());
+    }
+
+    std::vector<real> FastTextApi::getSentenceVector(const std::string& sentence) {
+        Vector vec(privateMembers->args_->dim);
+        std::istringstream in(sentence);
+        fastText.getSentenceVector(in, vec);
         return std::vector<real>(vec.data(), vec.data() + vec.size());
     }
 

--- a/src/main/cpp/fasttext_wrapper.h
+++ b/src/main/cpp/fasttext_wrapper.h
@@ -29,6 +29,7 @@ namespace FastTextWrapper {
         std::vector<std::string> predict(const std::string&, int32_t);
         std::vector<std::pair<real,std::string>> predictProba(const std::string&, int32_t);
         std::vector<real> getVector(const std::string&);
+        std::vector<real> getSentenceVector(const std::string&);
         std::vector<std::string> getWords();
         std::vector<std::string> getLabels();
         std::string getWord(int32_t);

--- a/src/main/java/com/github/jfasttext/FastTextWrapper.java
+++ b/src/main/java/com/github/jfasttext/FastTextWrapper.java
@@ -201,6 +201,8 @@ public class FastTextWrapper extends com.github.jfasttext.config.FastTextWrapper
         public native @ByVal FloatStringPairVector predictProba(@StdString String arg0, int arg1);
         public native @ByVal RealVector getVector(@StdString BytePointer arg0);
         public native @ByVal RealVector getVector(@StdString String arg0);
+        public native @ByVal RealVector getSentenceVector(@StdString BytePointer arg0);
+        public native @ByVal RealVector getSentenceVector(@StdString String arg0);
         public native @ByVal StringVector getWords();
         public native @ByVal StringVector getLabels();
         public native @StdString BytePointer getWord(int arg0);

--- a/src/main/java/com/github/jfasttext/JFastText.java
+++ b/src/main/java/com/github/jfasttext/JFastText.java
@@ -151,6 +151,27 @@ public class JFastText {
         return wordVec;
     }
 
+    public float[] getArrayVector(String word) {
+        FastTextWrapper.RealVector rv = fta.getVector(word);
+        float[] wordVec = new float[(int)rv.size()];
+        for (int i = 0; i < rv.size(); i++) {
+            wordVec[i] = rv.get(i);
+        }
+        return wordVec;
+    }
+
+    public List<Float> getSentenceVector(String sentence) {
+        if (!sentence.endsWith("\n")) {
+          sentence += "\n";
+        }
+        FastTextWrapper.RealVector rv = fta.getSentenceVector(sentence);
+        List<Float> wordVec = new ArrayList<>();
+        for (int i = 0; i < rv.size(); i++) {
+          wordVec.add(rv.get(i));
+        }
+        return wordVec;
+    }
+
     public int getNWords() {
         return fta.getNWords();
     }

--- a/src/test/java/com/github/jfasttext/JFastTextTest.java
+++ b/src/test/java/com/github/jfasttext/JFastTextTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotNull;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class JFastTextTest {
@@ -154,7 +155,9 @@ public class JFastTextTest {
      */
     @Test
     public void test10ModelFromURL() throws Exception {
-        URL modelUrl = this.getClass().getClassLoader().getResource("models/supervised.model.bin");
+        String modelFile = "models/supervised.model.bin";
+        URL modelUrl = this.getClass().getClassLoader().getResource(modelFile);
+        assertNotNull(String.format("Failed to locate model '%s'", modelFile), modelUrl);
         JFastText jft = new JFastText(modelUrl);
         System.out.printf("\tnumber of words = %d\n", jft.getNWords());
     }

--- a/src/test/java/com/github/jfasttext/JFastTextTest.java
+++ b/src/test/java/com/github/jfasttext/JFastTextTest.java
@@ -4,6 +4,9 @@ import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.URL;
 import java.util.List;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -57,8 +60,7 @@ public class JFastTextTest {
 
     @Test
     public void test05PredictProba() throws Exception {
-        JFastText jft = new JFastText();
-        jft.loadModel("src/test/resources/models/supervised.model.bin");
+        JFastText jft = new JFastText("src/test/resources/models/supervised.model.bin");
         String text = "What is the most popular sport in the US ?";
         JFastText.ProbLabel predictedProbLabel = jft.predictProba(text);
         System.out.printf("\nText: '%s', label: '%s', probability: %f\n",
@@ -67,8 +69,7 @@ public class JFastTextTest {
 
     @Test
     public void test06MultiPredictProba() throws Exception {
-        JFastText jft = new JFastText();
-        jft.loadModel("src/test/resources/models/supervised.model.bin");
+        JFastText jft = new JFastText("src/test/resources/models/supervised.model.bin");
         String text = "Do you like soccer ?";
         System.out.printf("Text: '%s'\n", text);
         for (JFastText.ProbLabel predictedProbLabel: jft.predictProba(text, 2)) {
@@ -79,11 +80,12 @@ public class JFastTextTest {
 
     @Test
     public void test07GetVector() throws Exception {
-        JFastText jft = new JFastText();
-        jft.loadModel("src/test/resources/models/supervised.model.bin");
-        String word = "soccer";
-        List<Float> vec = jft.getVector(word);
-        System.out.printf("\nWord embedding vector of '%s': %s\n", word, vec);
+        try (InputStream is = new FileInputStream("src/test/resources/models/supervised.model.bin")) {
+            JFastText jft = new JFastText(is);
+            String word = "soccer";
+            List<Float> vec = jft.getVector(word);
+            System.out.printf("\nWord embedding vector of '%s': %s\n", word, vec);
+        }
     }
 
     /**
@@ -92,8 +94,7 @@ public class JFastTextTest {
     @Test
     public void test08ModelInfo() throws Exception {
         System.out.printf("\nSupervised model information:\n");
-        JFastText jft = new JFastText();
-        jft.loadModel("src/test/resources/models/supervised.model.bin");
+        JFastText jft = new JFastText("src/test/resources/models/supervised.model.bin");
         System.out.printf("\tnumber of words = %d\n", jft.getNWords());
         System.out.printf("\twords = %s\n", jft.getWords());
         System.out.printf("\tlearning rate = %g\n", jft.getLr());
@@ -119,5 +120,16 @@ public class JFastTextTest {
         jft.loadModel("src/test/resources/models/supervised.model.bin");
         System.out.println("Unloading model ...");
         jft.unloadModel();
+    }
+
+    /**
+     * Loads model from specified URL (resource, web, etc.)
+     *
+     */
+    @Test
+    public void test10ModelFromURL() throws Exception {
+        URL modelUrl = this.getClass().getClassLoader().getResource("models/supervised.model.bin");
+        JFastText jft = new JFastText(modelUrl);
+        System.out.printf("\tnumber of words = %d\n", jft.getNWords());
     }
 }

--- a/src/test/java/com/github/jfasttext/JFastTextTest.java
+++ b/src/test/java/com/github/jfasttext/JFastTextTest.java
@@ -9,6 +9,10 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+
+import static org.junit.Assert.assertArrayEquals;
+
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class JFastTextTest {
 
@@ -19,7 +23,9 @@ public class JFastTextTest {
         jft.runCmd(new String[] {
                 "supervised",
                 "-input", "src/test/resources/data/labeled_data.txt",
-                "-output", "src/test/resources/models/supervised.model"
+                "-output", "src/test/resources/models/supervised.model",
+                "-wordNgrams", "3",
+                "-bucket", "100"
         });
     }
 
@@ -58,6 +64,16 @@ public class JFastTextTest {
         System.out.printf("\nText: '%s', label: '%s'\n", text, predictedLabel);
     }
 
+	@Test
+	public void test04getArrayVector() throws Exception {
+		JFastText jft = new JFastText();
+		jft.loadModel("src/test/resources/models/supervised.model.bin");
+		String text = "I like soccer";
+		float[] predictedArray = jft.getArrayVector(text);
+		float[] expected = new float[100];
+		assertArrayEquals("", predictedArray, expected, 0.1f);
+	}
+
     @Test
     public void test05PredictProba() throws Exception {
         JFastText jft = new JFastText("src/test/resources/models/supervised.model.bin");
@@ -88,11 +104,21 @@ public class JFastTextTest {
         }
     }
 
+    @Test
+    public void test08GetSentenceVector() throws Exception {
+        JFastText jft = new JFastText();
+        jft.loadModel("src/test/resources/models/supervised.model.bin");
+        String word = "soccers";
+        List<Float> vec = jft.getSentenceVector(word);
+        int expectedSize = 100;
+        assertEquals(expectedSize, vec.size());
+    }
+
     /**
      * Test retrieving model's information: words, labels, learning rate, etc.
      */
     @Test
-    public void test08ModelInfo() throws Exception {
+    public void test09ModelInfo() throws Exception {
         System.out.printf("\nSupervised model information:\n");
         JFastText jft = new JFastText("src/test/resources/models/supervised.model.bin");
         System.out.printf("\tnumber of words = %d\n", jft.getNWords());
@@ -114,7 +140,7 @@ public class JFastTextTest {
      * allocated by native function calls).
      */
     @Test
-    public void test09ModelUnloading() throws Exception {
+    public void test10ModelUnloading() throws Exception {
         JFastText jft = new JFastText();
         System.out.println("\nLoading model ...");
         jft.loadModel("src/test/resources/models/supervised.model.bin");


### PR DESCRIPTION
* Added corresponding implementations of the `loadModel` that copy data from
  `InputStream`/`URL`/`URI` into temporary file, and load it into fastText;
* Added corresponding constructors to simplify code